### PR TITLE
[FLINK-18356][test-stability] Adopt Jemalloc as default memory allocator in CI docker to avoid memory leak

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:xenial
 # install packages
 RUN set -eux; \
 	apt-get update; apt-get upgrade -y ; \
-	apt-get install -y gosu sudo locales make less build-essential openjdk-8-jdk curl libapr1 unzip uuid-runtime jq bsdmainutils wget python docker.io psmisc software-properties-common apt-transport-https; \
+	apt-get install -y gosu sudo locales make less build-essential openjdk-8-jdk libjemalloc-dev curl libapr1 unzip uuid-runtime jq bsdmainutils wget python docker.io psmisc software-properties-common apt-transport-https; \
 	rm -rf /var/lib/apt/lists/*;
 
 # Install latest git
@@ -32,6 +32,7 @@ RUN update-alternatives --set javadoc /usr/lib/jvm/java-8-openjdk-amd64/bin/java
 ENV JAVA_HOME_8_X64 "/usr/lib/jvm/java-8-openjdk-amd64"
 ENV JAVA_HOME_11_X64 "/usr/lib/jvm/adoptopenjdk-11-hotspot-amd64"
 ENV JAVA_HOME "/usr/lib/jvm/java-8-openjdk-amd64"
+ENV LD_PRELOAD="/usr/lib/x86_64-linux-gnu/libjemalloc.so"
 
 # Install go
 RUN mkdir -p /usr/share/go \


### PR DESCRIPTION
This PR is aims to fix the memory leak problem in Flink CI. Please refer to [https://issues.apache.org/jira/browse/FLINK-18356](FLINK-18356) for detailed reasons.
